### PR TITLE
Fix warnings and messages

### DIFF
--- a/Solutions/.editorconfig
+++ b/Solutions/.editorconfig
@@ -68,3 +68,6 @@ dotnet_style_qualification_for_field = true:suggestion
 dotnet_style_qualification_for_method = true:suggestion
 dotnet_style_qualification_for_property = true:suggestion
 dotnet_style_qualification_for_event = true:suggestion
+
+# Non-endjin rules to avoid warnings arising from the fact that this code was forked
+csharp_prefer_braces = when_multiline:warning

--- a/Solutions/Corvus.DotLiquidAsync.Specs/Corvus.DotLiquidAsync.Specs.csproj
+++ b/Solutions/Corvus.DotLiquidAsync.Specs/Corvus.DotLiquidAsync.Specs.csproj
@@ -5,6 +5,26 @@
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <RootNamespace>Corvus.Extensions.Specs</RootNamespace>
+
+    <!--
+    RCS1090 - disabling ConfigureAwait calls in test for now - we have a work item #26 for determining whether it's safe to put those back.
+    
+    Disabling warnings we'd normally accept to avoid non-functional changes that would make it hard to
+    see how this project differs from the one from which it was forked
+    RCS1018 - specify accessibility
+    RCS1021 - simplify lambda
+    RCS1036 - redundant empty lines
+    RCS1048 - use lambda not anonymous method
+    RCS1057 - missing empty lines
+    RCS1077 - optimize LINQ call and similar
+    RCS1089 - use ++
+    RCS1104 - simplify conditional expression
+    RCS1118 - make variables const
+    RCS1163 - unused parameters
+    RCS1170 - use auto-properties
+    RCS1192 - use regular string instead of '@'
+    -->
+    <NoWarn>RCS1018;RCS1021;RCS1036;RCS1048;RCS1057;RCS1077;RCS1089;RCS1090;RCS1104;RCS1118;RCS1163;RCS1170;RCS1192</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Solutions/Corvus.DotLiquidAsync.Specs/DropTests.cs
+++ b/Solutions/Corvus.DotLiquidAsync.Specs/DropTests.cs
@@ -292,7 +292,7 @@ namespace DotLiquid.Tests
             dataRow["Column1"] = "Hello";
             dataRow["Column2"] = "World";
 
-            var tpl = Template.Parse(" {{ row.column1 }} ");
+            var tpl = Template.Parse(" {{ row.Column1 }} ");
             Assert.AreEqual(" Hello ", await tpl.RenderAsync(Hash.FromAnonymousObject(new { row = new DataRowDrop(dataRow) })));
         }
 

--- a/Solutions/Corvus.DotLiquidAsync.Specs/Helper.cs
+++ b/Solutions/Corvus.DotLiquidAsync.Specs/Helper.cs
@@ -4,7 +4,7 @@ namespace DotLiquid.Tests
     using NUnit.Framework;
     using System.Threading.Tasks;
 
-    public class Helper
+    public static class Helper
     {
         public static async Task AssertTemplateResultAsync(string expected, string template, Hash localVariables, INamingConvention namingConvention)
         {

--- a/Solutions/Corvus.DotLiquidAsync/Corvus.DotLiquidAsync.csproj
+++ b/Solutions/Corvus.DotLiquidAsync/Corvus.DotLiquidAsync.csproj
@@ -13,6 +13,32 @@
 
   <Import Project="..\Common.NetStandard_2_0.proj" />
 
+  <PropertyGroup>
+    <!--
+    There are various Roslynator warnings we disable because this was forked, and for the time being at least, we
+    want to avoid introducing superficial differences between this code and the original. Normally we would
+    conform with these rules, but in this case it makes it harder to see differences between this fork and
+    the original codebase
+    RCS1015 - use nameof
+    RCS1021 - simplify lambda
+    RCS1057 - missing empty lines
+    RCS1058 - use compound assignment
+    RCS1073 - convert if to return
+    RCS1077, RCS1080 - optimize LINQ call and similar
+    RCS1085, RCS1170 - use auto-properties
+    RCS1104 - simplify conditional expression
+    RCS1128 - Use coalesce
+    RCS1146 - Use conditional access
+    RCS1156 - use string.Length instead of comparison with empty
+    RCS1163 - unused parameters
+    RCS1192 - use regular string instead of '@'
+    RCS1220 - using pattern matching where applicable
+    RCS1226 - using paragraphs where suitable in xmldoc
+    RCS1235 - optimize string.Join
+    RCS1239 - use for instead of while
+    -->
+    <NoWarn>RCS1015;RCS1021;RCS1057;RCS1058;RCS1073;RCS1077;RCS1080;RCS1085;RCS1104;RCS1128;RCS1146;RCS1156;RCS1163;RCS1170;RCS1192;RCS1220;RCS1226;RCS1235;RCS1239</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Update="DotLiquid\Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/Solutions/Corvus.DotLiquidAsync/DotLiquid/Condition.cs
+++ b/Solutions/Corvus.DotLiquidAsync/DotLiquid/Condition.cs
@@ -119,7 +119,7 @@ namespace DotLiquid
                 {
                     right = Convert.ChangeType(right, left.GetType());
                 }
-                catch (Exception)
+                catch
                 {
                 }
             }

--- a/Solutions/Corvus.DotLiquidAsync/DotLiquid/Document.cs
+++ b/Solutions/Corvus.DotLiquidAsync/DotLiquid/Document.cs
@@ -51,7 +51,7 @@ namespace DotLiquid
         {
             try
             {
-                await base.RenderAsync(context, result);
+                await base.RenderAsync(context, result).ConfigureAwait(false);
             }
             catch (BreakInterrupt)
             {

--- a/Solutions/Corvus.DotLiquidAsync/DotLiquid/Hash.cs
+++ b/Solutions/Corvus.DotLiquidAsync/DotLiquid/Hash.cs
@@ -20,7 +20,7 @@ namespace DotLiquid
         private readonly object defaultValue;
 
         /// <summary>
-        ///
+        /// Build a hash from the properties of an object of any type (including anonymous types).
         /// </summary>
         /// <param name="anonymousObject"></param>
         /// <param name="includeBaseClassProperties">If this is set to true, method will map base class' properties too. </param>

--- a/Solutions/Corvus.DotLiquidAsync/DotLiquid/LiquidTypeAttribute.cs
+++ b/Solutions/Corvus.DotLiquidAsync/DotLiquid/LiquidTypeAttribute.cs
@@ -19,7 +19,7 @@ namespace DotLiquid
         public string[] AllowedMembers { get; private set; }
 
         /// <summary>
-        ///
+        /// Creates a <see cref="LiquidTypeAttribute"/>.
         /// </summary>
         /// <param name="allowedMembers">An array of property and method names that are allowed to be called on the object.</param>
         public LiquidTypeAttribute(params string[] allowedMembers)

--- a/Solutions/Corvus.DotLiquidAsync/DotLiquid/Tag.cs
+++ b/Solutions/Corvus.DotLiquidAsync/DotLiquid/Tag.cs
@@ -91,7 +91,7 @@ namespace DotLiquid
         internal async Task<string> RenderAsync(Context context)
         {
             using TextWriter result = new StringWriter(context.FormatProvider);
-            await this.RenderAsync(context, result);
+            await this.RenderAsync(context, result).ConfigureAwait(false);
             return result.ToString();
         }
     }

--- a/Solutions/Corvus.DotLiquidAsync/DotLiquid/Template.cs
+++ b/Solutions/Corvus.DotLiquidAsync/DotLiquid/Template.cs
@@ -396,8 +396,8 @@ namespace DotLiquid
             // Can't dispose this new StreamWriter, because it would close the
             // passed-in stream, which isn't up to us.
             using StreamWriter streamWriter = new StreamWriterWithFormatProvider(stream, parameters.FormatProvider);
-            await this.RenderInternalAsync(streamWriter, parameters);
-            await streamWriter.FlushAsync();
+            await this.RenderInternalAsync(streamWriter, parameters).ConfigureAwait(false);
+            await streamWriter.FlushAsync().ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Solutions/Corvus.DotLiquidAsync/DotLiquid/Variable.cs
+++ b/Solutions/Corvus.DotLiquidAsync/DotLiquid/Variable.cs
@@ -113,7 +113,7 @@ namespace DotLiquid
         {
             if (this.Name == null)
             {
-                return null;
+                return Task.FromResult<object>(null);
             }
 
             object output = context[this.Name];

--- a/Solutions/Corvus.DotLiquidAsync/GlobalSuppressions.cs
+++ b/Solutions/Corvus.DotLiquidAsync/GlobalSuppressions.cs
@@ -1,0 +1,18 @@
+﻿// <copyright file="GlobalSuppressions.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+// <summary>
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+// </summary>
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage(
+    "Design",
+    "RCS1194:Implement exception constructors.",
+    Justification = "These exceptions are designed to be thrown by this project, and are not for general use by other code, so they do not need all the normal overloads",
+    Scope = "namespaceanddescendants",
+    Target = "DotLiquid.Exceptions")]

--- a/Solutions/DotLiquidAsync.sln
+++ b/Solutions/DotLiquidAsync.sln
@@ -5,6 +5,7 @@ VisualStudioVersion = 16.0.29319.158
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2CF66DE5-5452-415E-B932-AC63BBD5648A}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		..\appveyor.yml = ..\appveyor.yml
 		..\CHANGELOG.markdown = ..\CHANGELOG.markdown
 		..\README.markdown = ..\README.markdown


### PR DESCRIPTION
Resolves #31

Since this project is a fork of another project, these changes mostly disable various warnings and messages. The rationale for this is that fixing the warnings by changing the code would make it much harder to tell how this fork differs from the original project, because it would add large numbers of superficial changes, making the substantive ones harder to spot.

Only in cases where the messages or warnings indicated a genuine problem has the code been modified.